### PR TITLE
Handle missing transformers dependency

### DIFF
--- a/PWM_VISION.py
+++ b/PWM_VISION.py
@@ -17,7 +17,15 @@ import cv2
 import numpy as np
 import torch
 from PIL import Image
-from transformers import pipeline
+
+try:
+    from transformers import pipeline
+except ModuleNotFoundError as exc:  # pragma: no cover - environment guard
+    missing_pkg = exc.name or "transformers"
+    raise SystemExit(
+        "Required dependency missing: '{pkg}'. Install it with "
+        "`pip install {pkg}` before running PWM_VISION.py".format(pkg=missing_pkg)
+    ) from exc
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add a user-friendly error message when the transformers package is missing

## Testing
- no tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d54b45b4988322964ccc1c22deb766