### PR TITLE
Remove redundant global declaration for blue_x

### DIFF
--- a/Direction_Control.py
+++ b/Direction_Control.py
@@ -365,7 +365,6 @@ try:
         gap_cx = center_x if len(red_xs_in_zone) == 0 else widest_gap_center(blockers_all, preferred_x=center_x)
 
         # Smooth & draw
-        global blue_x
         if blue_x is None:
             blue_x = float(gap_cx)
         else:


### PR DESCRIPTION
## Summary
- remove the redundant `global blue_x` declaration inside the main loop to resolve the SyntaxError raised at runtime

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5c0eb15e48322b8db9f492cb3d151