### PR TITLE
Add GPIO fallback when running off Jetson

### DIFF
--- a/Direction_Control.py
+++ b/Direction_Control.py
@@ -24,7 +24,43 @@ import torch
 from PIL import Image
 from transformers import pipeline
 
-import Jetson.GPIO as GPIO  # <-- for AIN1/AIN2/STBY control
+try:
+    import Jetson.GPIO as GPIO  # <-- for AIN1/AIN2/STBY control
+    _GPIO_AVAILABLE = True
+except Exception as exc:  # pragma: no cover - fallback path on non-Jetson systems
+    _GPIO_AVAILABLE = False
+
+    class _DummyGPIO:
+        """Minimal stub matching the Jetson.GPIO API used in this script."""
+
+        BOARD = "BOARD"
+        HIGH = 1
+        LOW = 0
+
+        def __init__(self):
+            self._warned = False
+
+        def _warn(self):
+            if not self._warned:
+                print(
+                    f"[GPIO] Jetson.GPIO unavailable ({exc}). Using no-op GPIO stub. "
+                    "Motor control disabled."
+                )
+                self._warned = True
+
+        def setmode(self, *_args, **_kwargs):
+            self._warn()
+
+        def setup(self, *_args, **_kwargs):
+            self._warn()
+
+        def output(self, *_args, **_kwargs):
+            self._warn()
+
+        def cleanup(self, *_args, **_kwargs):
+            self._warn()
+
+    GPIO = _DummyGPIO()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- guard Jetson.GPIO import and provide a no-op stub when the module cannot determine the Jetson model
- notify the user that hardware control is disabled while continuing to allow the rest of the script to run

## Testing
- python -m compileall Direction_Control.py

------
https://chatgpt.com/codex/tasks/task_e_68d5c1f9684083229643b504dc028a05