### PR TITLE
Handle Jetson GPIO detection failure gracefully

### DIFF
--- a/Direction_Control.py
+++ b/Direction_Control.py
@@ -23,9 +23,10 @@ from transformers import pipeline
 try:
     import Jetson.GPIO as GPIO
     GPIO_AVAILABLE = True
-except ImportError:  # pragma: no cover - Jetson specific hardware dependency
+except Exception as exc:  # pragma: no cover - Jetson specific hardware dependency
     GPIO = None
     GPIO_AVAILABLE = False
+    print(f"Jetson GPIO unavailable ({exc}). Running in no-GPIO mode.")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- catch any exception raised while importing Jetson.GPIO so the script can run on non-Jetson hardware
- log a clear message and fall back to running without GPIO when Jetson model detection fails

## Testing
- not run (hardware specific script)


------
https://chatgpt.com/codex/tasks/task_e_68d5c84119e883228a34e68f8cba95f2