### PR TITLE
Drive pin 31 high during PWM run

### DIFF
--- a/pwmControl.py
+++ b/pwmControl.py
@@ -3,6 +3,21 @@
 
 import os, time
 
+# ===== Optional GPIO configuration =====
+# Pin 31 on the 40-pin header typically maps to a GPIO line that can be driven
+# as a digital output.  The default below targets the common Jetson Xavier NX
+# mapping (physical pin 31 -> gpio298).  You can override this by setting the
+# PIN31_GPIO environment variable to the correct Linux GPIO number for your
+# board, or set it to an empty string to disable the behaviour entirely.
+_pin31_override = os.environ.get("PIN31_GPIO")
+if _pin31_override is None:
+    GPIO_LINE = 298
+elif _pin31_override == "":
+    GPIO_LINE = None
+else:
+    GPIO_LINE = int(_pin31_override)
+GPIO_ROOT = "/sys/class/gpio"
+
 # ===== User-tunable settings =====
 PWMCHIP = "/sys/class/pwm/pwmchip3"  # adjust if your board exposes a different pwmchipN
 CHANNEL = "pwm0"
@@ -26,53 +41,94 @@ def wr(path, val):
     with open(path, "w") as f:
         f.write(str(val))
 
-# Export channel if needed
-if not os.path.isdir(CH_PATH):
-    if not os.path.isdir(PWMCHIP):
-        raise FileNotFoundError(f"{PWMCHIP} does not exist. Check which pwmchipN is present.")
-    wr(f"{PWMCHIP}/export", "0")
-    # Wait for pwm0 directory to appear
-    for _ in range(200):
-        if os.path.isdir(CH_PATH):
-            break
-        time.sleep(0.01)
-    else:
-        raise TimeoutError("pwm0 did not appear after export")
+def wait_for_path(path: str, attempts: int = 200, delay_s: float = 0.01) -> bool:
+    for _ in range(attempts):
+        if os.path.isdir(path) or os.path.isfile(path):
+            return True
+        time.sleep(delay_s)
+    return False
 
-# Always disable before (re)configuring
-try:
-    wr(f"{CH_PATH}/enable", "0")
-except OSError:
-    pass
+def setup_gpio_high():
+    if GPIO_LINE is None:
+        return lambda: None
 
-# Configure base frequency
-PERIOD_NS = ns_period(FREQ_HZ)
-wr(f"{CH_PATH}/period", PERIOD_NS)
+    if not os.path.isdir(GPIO_ROOT):
+        raise FileNotFoundError(f"{GPIO_ROOT} does not exist on this system")
 
-# Start at 0% duty for soft-start
-wr(f"{CH_PATH}/duty_cycle", 0)
+    gpio_path = f"{GPIO_ROOT}/gpio{GPIO_LINE}"
 
-# Enable output
-wr(f"{CH_PATH}/enable", "1")
+    if not os.path.isdir(gpio_path):
+        wr(f"{GPIO_ROOT}/export", GPIO_LINE)
+        if not wait_for_path(gpio_path):
+            raise TimeoutError(f"gpio{GPIO_LINE} did not appear after export")
 
-# Soft-start ramp to TARGET_DUTY_PCT
-final_dc_ns = ns_duty_from_pct(PERIOD_NS, TARGET_DUTY_PCT)
-if SOFT_START_S > 0 and RAMP_STEPS > 0 and final_dc_ns > 0:
-    step_sleep = SOFT_START_S / RAMP_STEPS
-    for i in range(1, RAMP_STEPS + 1):
-        dc = int(final_dc_ns * (i / RAMP_STEPS))
-        wr(f"{CH_PATH}/duty_cycle", dc)
-        time.sleep(step_sleep)
-else:
-    wr(f"{CH_PATH}/duty_cycle", final_dc_ns)
+    wr(f"{gpio_path}/direction", "out")
+    wr(f"{gpio_path}/value", "1")
 
-print(f"{FREQ_HZ:,} Hz @ {TARGET_DUTY_PCT:.1f}% set. Ctrl+C to stop.")
+    def cleanup():
+        try:
+            wr(f"{gpio_path}/value", "0")
+        except OSError:
+            pass
 
-try:
-    while True:
-        time.sleep(1)
-except KeyboardInterrupt:
+    return cleanup
+
+def main():
+    gpio_cleanup = lambda: None
+
     try:
-        wr(f"{CH_PATH}/enable", "0")
-    except OSError:
+        gpio_cleanup = setup_gpio_high()
+
+        # Export channel if needed
+        if not os.path.isdir(CH_PATH):
+            if not os.path.isdir(PWMCHIP):
+                raise FileNotFoundError(f"{PWMCHIP} does not exist. Check which pwmchipN is present.")
+            wr(f"{PWMCHIP}/export", "0")
+            # Wait for pwm0 directory to appear
+            if not wait_for_path(CH_PATH):
+                raise TimeoutError("pwm0 did not appear after export")
+
+        # Always disable before (re)configuring
+        try:
+            wr(f"{CH_PATH}/enable", "0")
+        except OSError:
+            pass
+
+        # Configure base frequency
+        PERIOD_NS = ns_period(FREQ_HZ)
+        wr(f"{CH_PATH}/period", PERIOD_NS)
+
+        # Start at 0% duty for soft-start
+        wr(f"{CH_PATH}/duty_cycle", 0)
+
+        # Enable output
+        wr(f"{CH_PATH}/enable", "1")
+
+        # Soft-start ramp to TARGET_DUTY_PCT
+        final_dc_ns = ns_duty_from_pct(PERIOD_NS, TARGET_DUTY_PCT)
+        if SOFT_START_S > 0 and RAMP_STEPS > 0 and final_dc_ns > 0:
+            step_sleep = SOFT_START_S / RAMP_STEPS
+            for i in range(1, RAMP_STEPS + 1):
+                dc = int(final_dc_ns * (i / RAMP_STEPS))
+                wr(f"{CH_PATH}/duty_cycle", dc)
+                time.sleep(step_sleep)
+        else:
+            wr(f"{CH_PATH}/duty_cycle", final_dc_ns)
+
+        print(f"{FREQ_HZ:,} Hz @ {TARGET_DUTY_PCT:.1f}% set. Ctrl+C to stop.")
+
+        while True:
+            time.sleep(1)
+    except KeyboardInterrupt:
         pass
+    finally:
+        try:
+            wr(f"{CH_PATH}/enable", "0")
+        except OSError:
+            pass
+
+        gpio_cleanup()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add GPIO setup that drives the pin 31 line high on start and releases it on shutdown
- refactor the PWM script into a main routine with shared helpers for path waiting and cleanup

## Testing
- python -m compileall pwmControl.py

------
https://chatgpt.com/codex/tasks/task_e_68d6ebaf07208322b90cca51b27d81c3