### PR TITLE
Make braking PWM proportional to encoder error

### DIFF
--- a/BRAKING_STEERING.py
+++ b/BRAKING_STEERING.py
@@ -899,7 +899,14 @@ def update_braking_motor_control(target_norm, encoder_norm, max_duty_pct=None):
         return
 
     duty_cap = braking_motor_max_duty_pct if max_duty_pct is None else max_duty_pct
-    duty_pct = max(0.0, min(duty_cap, braking_motor_max_duty_pct))
+    duty_cap = max(0.0, min(float(duty_cap), braking_motor_max_duty_pct))
+    denom = (
+        float(braking_motor_full_speed_error_norm)
+        if braking_motor_full_speed_error_norm > 0
+        else 1.0
+    )
+    scaled_pct = (abs(error) / denom) * duty_cap
+    duty_pct = max(0.0, min(duty_cap, scaled_pct))
 
     _set_braking_motor_direction(error)
 


### PR DESCRIPTION
### Motivation
- The braking motor was overshooting its target and ignoring calibration because PWM duty was effectively held at the configured cap instead of being scaled by encoder error.
- Improve braking responsiveness so the encoder calibration actually determines stop position and the motor tapers as it approaches the target.

### Description
- Updated `BRAKING_STEERING.py` in `update_braking_motor_control()` to clamp `duty_cap`, compute a denominator from `braking_motor_full_speed_error_norm`, scale PWM by `abs(error)` and then clamp the resulting `duty_pct` before applying it.
- The change makes braking PWM proportional to the encoder error magnitude instead of always using the cap, preserving existing dead-zone and power pin logic.
- Only `BRAKING_STEERING.py` was modified.

### Testing
- Compiled the module with `python -m py_compile /workspace/Depth-Vision-Control/BRAKING_STEERING.py` and the compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f23526e12083228a6b0f47eb08053f)