### PR TITLE
Fix brake encoder calibration normalization span

### DIFF
--- a/BRAKING_STEERING.py
+++ b/BRAKING_STEERING.py
@@ -493,6 +493,13 @@ def load_braking_calibration():
 BRAKING_ENCODER_COUNTS = 4096
 
 
+def _encoder_signed_delta(start_raw, end_raw, counts=BRAKING_ENCODER_COUNTS):
+    """Return shortest signed delta from start_raw to end_raw in encoder counts."""
+    half = counts // 2
+    delta = (int(end_raw) - int(start_raw) + half) % counts - half
+    return int(delta)
+
+
 def save_braking_calibration(released_raw, pressed_raw):
     global braking_calibration_data, braking_calibration_loaded
     braking_calibration_data = {
@@ -508,8 +515,8 @@ def braking_encoder_span():
     pressed_raw = braking_calibration_data["pressed_raw"]
     if released_raw is None or pressed_raw is None:
         return None
-    span = (pressed_raw - released_raw) % BRAKING_ENCODER_COUNTS
-    return span if span > 0 else None
+    span = _encoder_signed_delta(released_raw, pressed_raw)
+    return span if span != 0 else None
 
 
 def read_braking_encoder_raw():
@@ -531,7 +538,7 @@ def braking_encoder_raw_to_norm(raw):
     released_raw = braking_calibration_data["released_raw"]
     if released_raw is None:
         return None
-    progress = (int(raw) - int(released_raw)) % BRAKING_ENCODER_COUNTS
+    progress = _encoder_signed_delta(released_raw, raw)
     norm = progress / span
     return float(clamp(norm, 0.0, 1.0))
 
@@ -1068,7 +1075,7 @@ def capture_braking_calibration_point():
         braking_calibration_samples["max"] = raw
         released_raw = braking_calibration_samples["min"]
         pressed_raw = braking_calibration_samples["max"]
-        span = (pressed_raw - released_raw) % BRAKING_ENCODER_COUNTS
+        span = _encoder_signed_delta(released_raw, pressed_raw)
         if span == 0:
             braking_calibration_status_text, braking_calibration_status_until = set_status_message(
                 "Brake cal failed: encoder range is zero",


### PR DESCRIPTION
### Motivation
- Brake encoder reported `1.000` at incorrect positions and hit ends prematurely due to modulo-only span/progress math that ignored wrap direction. 
- The calibration and runtime normalization used one-way wrapping which produced a too-short positive span across the encoder wrap boundary. 
- The intent is to make saved calibration and live normalization use the shortest signed path around the encoder ring so released ≈ `0.000` and pressed ≈ `1.000` consistently.

### Description
- Added a helper `
_encoder_signed_delta(start_raw, end_raw, counts=BRAKING_ENCODER_COUNTS)
` that computes the shortest signed delta across the encoder wrap. 
- Replaced modulo-only span computation with `_encoder_signed_delta` in `braking_encoder_span()` and in the braking calibration validation path. 
- Replaced modulo progress calculation in `braking_encoder_raw_to_norm()` with the signed-delta progress so runtime normalization follows the same signed shortest-path logic.

### Testing
- Compiled the updated file with `python -m py_compile BRAKING_STEERING.py`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f248713604832296ae7b9d29daf586)