### PR TITLE
Add P hotkey to trigger a 5-second brake press

### DIFF
--- a/BRAKING_STEERING.py
+++ b/BRAKING_STEERING.py
@@ -1878,6 +1878,7 @@ while True:
                 "V/N: Brake jog Release/Press",
                 "C: Start steer calibration",
                 "X: Start brake calibration",
+                "P: Press brake for 5 seconds",
                 "SPACE: Capture calibration",
             ]
             draw_help_overlay(
@@ -2003,6 +2004,12 @@ while True:
                 enable_motor_pwm()
             ui_notice_text = "Brake jog disabled"
             ui_notice_until = time.time() + 3.0
+    if key == ord('p'):
+        brake_hold_until = time.monotonic() + 5.0
+        ui_notice_text = "Brake pressed for 5 seconds"
+        ui_notice_until = time.monotonic() + 2.0
+
+
 
     if calibration_active and key in (ord('a'), ord('d')):
         requested_direction = -1 if key == ord('a') else 1


### PR DESCRIPTION
### Motivation
- Provide a quick operator hotkey to force the braking actuator to the pressed position for a short, deterministic interval without changing existing auto-brake logic by reusing the existing hold timer.

### Description
- Add a help-line `"P: Press brake for 5 seconds"` to the on-screen help and handle `if key == ord('p'):` to set `brake_hold_until = time.monotonic() + 5.0` and display a short UI notice via `ui_notice_text`/`ui_notice_until`.

### Testing
- Compiled the modified file with `python -m py_compile BRAKING_STEERING.py`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8ccf88ff08322a8a3b6762e85cb1e)