### PR TITLE
Fix braking encoder calibration not persisting across reruns

### DIFF
--- a/BRAKING_STEERING.py
+++ b/BRAKING_STEERING.py
@@ -159,13 +159,14 @@ confidence_text_margin = 12
 # Encoder + steering control configuration
 encoder_i2c_bus = 7
 encoder_i2c_address = 0x36
-calibration_file = Path("steering_calibration.json")
+script_dir = Path(__file__).resolve().parent
+calibration_file = script_dir / "steering_calibration.json"
 simulated_step_norm = 0.01        # arrow-key increment when in simulated encoder mode
 
 # Encoder + braking control configuration
 braking_encoder_i2c_bus = 1
 braking_encoder_i2c_address = 0x36
-braking_calibration_file = Path("braking_calibration.json")
+braking_calibration_file = script_dir / "braking_calibration.json"
 
 
 # ---------------------------------------------------------------------------
@@ -413,6 +414,7 @@ def save_calibration(min_raw, center_raw, max_raw):
         "encoder_center_raw": int(center_raw),
         "encoder_max_raw": int(max_raw),
     }
+    calibration_file.parent.mkdir(parents=True, exist_ok=True)
     calibration_file.write_text(json.dumps(calibration_data, indent=2))
     calibration_loaded = True
 
@@ -514,6 +516,7 @@ def save_braking_calibration(min_raw, max_raw):
         "encoder_min_raw": int(min_raw),
         "encoder_max_raw": int(max_raw),
     }
+    braking_calibration_file.parent.mkdir(parents=True, exist_ok=True)
     braking_calibration_file.write_text(json.dumps(braking_calibration_data, indent=2))
     braking_calibration_loaded = True
 


### PR DESCRIPTION
### Motivation
- Calibration files were resolved relative to the process working directory, so restarting the program from a different CWD made saved braking/steering calibration appear lost.

### Description
- Anchor calibration file paths to the script location by adding `script_dir = Path(__file__).resolve().parent` and using `script_dir / "steering_calibration.json"` and `script_dir / "braking_calibration.json"`.
- Create parent directories before writing calibration files by calling `calibration_file.parent.mkdir(parents=True, exist_ok=True)` and the same for `braking_calibration_file` to avoid silent write failures.

### Testing
- Verified the modified file compiles with `python -m py_compile BRAKING_STEERING.py` (no errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8f735fbf883228979ce5d54504333)