### PR TITLE
Auto-rezero brake encoder after stable release drop

### DIFF
--- a/BRAKING_STEERING.py
+++ b/BRAKING_STEERING.py
@@ -607,6 +607,15 @@ braking_calibration_jog_direction = 0
 braking_target_norm = None
 brake_hold_until = 0.0
 brake_press_timestamps = deque()
+brake_release_rezero_drop_norm = 0.05
+brake_release_rezero_settle_seconds = 1.0
+brake_release_rezero_up_tolerance_norm = 0.005
+brake_release_candidate_active = False
+brake_release_candidate_start_norm = None
+brake_release_candidate_lowest_norm = None
+brake_release_candidate_lowest_raw = None
+brake_release_candidate_last_drop_time = 0.0
+brake_release_candidate_disqualified = False
 
 brake_shutdown_press_count = 5
 brake_shutdown_window_seconds = 6.0
@@ -1030,6 +1039,12 @@ def shutdown_braking_motor_control():
 
 def get_braking_encoder_norm():
     global braking_latest_encoder_raw, braking_latest_encoder_norm
+    global brake_release_candidate_active
+    global brake_release_candidate_start_norm
+    global brake_release_candidate_lowest_norm
+    global brake_release_candidate_lowest_raw
+    global brake_release_candidate_last_drop_time
+    global brake_release_candidate_disqualified
     raw = read_braking_encoder_raw()
     braking_latest_encoder_raw = raw
     if raw is None:
@@ -1037,6 +1052,57 @@ def get_braking_encoder_norm():
         return None
     norm = braking_encoder_raw_to_norm(raw)
     braking_latest_encoder_norm = norm
+    if norm is None:
+        return None
+
+    now = time.monotonic()
+
+    if not brake_release_candidate_active:
+        brake_release_candidate_active = True
+        brake_release_candidate_start_norm = norm
+        brake_release_candidate_lowest_norm = norm
+        brake_release_candidate_lowest_raw = raw
+        brake_release_candidate_last_drop_time = now
+        brake_release_candidate_disqualified = False
+        return norm
+
+    if brake_release_candidate_start_norm is None or brake_release_candidate_lowest_norm is None:
+        brake_release_candidate_active = False
+        return norm
+
+    if norm < brake_release_candidate_lowest_norm:
+        brake_release_candidate_lowest_norm = norm
+        brake_release_candidate_lowest_raw = raw
+        brake_release_candidate_last_drop_time = now
+    elif norm > (brake_release_candidate_lowest_norm + brake_release_rezero_up_tolerance_norm):
+        brake_release_candidate_disqualified = True
+
+    drop_amount = brake_release_candidate_start_norm - brake_release_candidate_lowest_norm
+    settle_elapsed = now - brake_release_candidate_last_drop_time
+    if (
+        drop_amount >= brake_release_rezero_drop_norm
+        and not brake_release_candidate_disqualified
+        and settle_elapsed >= brake_release_rezero_settle_seconds
+        and not braking_calibration_active
+    ):
+        new_zero_raw = brake_release_candidate_lowest_raw
+        max_raw = braking_calibration_data.get("encoder_max_raw")
+        if new_zero_raw is not None and max_raw is not None and int(max_raw) - int(new_zero_raw) > 0:
+            save_braking_calibration(int(new_zero_raw), int(max_raw))
+
+        brake_release_candidate_active = True
+        brake_release_candidate_start_norm = norm
+        brake_release_candidate_lowest_norm = norm
+        brake_release_candidate_lowest_raw = raw
+        brake_release_candidate_last_drop_time = now
+        brake_release_candidate_disqualified = False
+    elif brake_release_candidate_disqualified:
+        brake_release_candidate_start_norm = norm
+        brake_release_candidate_lowest_norm = norm
+        brake_release_candidate_lowest_raw = raw
+        brake_release_candidate_last_drop_time = now
+        brake_release_candidate_disqualified = False
+
     return norm
 
 


### PR DESCRIPTION
### Motivation
- Prevent encoder drift and lost brake-zero by automatically re-recording the brake "zero" whenever an obvious release (downward encoder movement) occurs and then settles, so the system remains calibrated without manual intervention.

### Description
- Added runtime tuning parameters and state for auto-rezero: `brake_release_rezero_drop_norm`, `brake_release_rezero_settle_seconds`, `brake_release_rezero_up_tolerance_norm`, and candidate tracking variables used to detect a qualified release. 
- Implemented detection in `get_braking_encoder_norm()` to track a downward movement, update the lowest observed point while it is dropping, disqualify if it rebounds, and when the drop is >= `0.05` normalized and stable for `1.0` second, save the low raw value as the new `encoder_min_raw` via `save_braking_calibration()`. 
- Added safeguards to avoid auto-rezero during active brake calibration and to verify the resulting `max_raw - new_min_raw` span is valid before persisting.

### Testing
- `python -m py_compile BRAKING_STEERING.py` succeeded without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9126e4e848322854a3a48fb33c015)