### PR TITLE
Add stall-detection and progress tracking to braking motor control

### DIFF
--- a/BRAKING_STEERING.py
+++ b/BRAKING_STEERING.py
@@ -140,6 +140,10 @@ braking_jog_duty_step_pct = 5.0
 brakeConf = 0.30  # brake when steerability confidence drops below this threshold
 brake_hold_seconds = 5.0  # keep brake fully pressed for this long after confidence-triggered braking
 braking_auto_max_duty_pct = 100.0  # max PWM duty allowed when auto-braking to press/release
+brake_press_stall_progress_norm = 0.006  # required new high-watermark increase to confirm real press progress
+brake_press_stall_noise_norm = 0.004  # ignore smaller encoder jitter while evaluating progress
+brake_press_stall_timeout_seconds = 0.80  # stop press drive only after sustained no-progress while pressing
+brake_press_stall_min_error_norm = 0.08  # only run stall detection when still meaningfully far from target
 
 # HUD text overlays on the combined frame
 hud_text_position = (10, 30)
@@ -623,6 +627,8 @@ brake_shutdown_window_seconds = 6.0
 brake_press_detect_threshold_norm = 0.90
 brake_release_detect_threshold_norm = 0.75
 brake_encoder_was_pressed = False
+brake_press_max_norm = None
+brake_press_last_progress_time = 0.0
 
 
 def _register_brake_press_and_maybe_shutdown() -> bool:
@@ -955,7 +961,12 @@ def enable_braking_motor_pwm() -> None:
 
 
 def update_braking_motor_control(target_norm, encoder_norm, max_duty_pct=None):
+    global brake_press_max_norm, brake_press_last_progress_time
+
+    now = time.monotonic()
     if target_norm is None or encoder_norm is None or braking_calibration_active:
+        brake_press_max_norm = None
+        brake_press_last_progress_time = now
         _set_braking_motor_direction(0)
         _set_braking_motor_pwm_pct(0.0)
         if GPIO is not None and braking_motor_gpio_initialised:
@@ -965,6 +976,34 @@ def update_braking_motor_control(target_norm, encoder_norm, max_duty_pct=None):
     error = float(target_norm) - float(encoder_norm)
 
     if abs(error) <= braking_motor_dead_zone_norm:
+        brake_press_max_norm = None
+        brake_press_last_progress_time = now
+        _set_braking_motor_direction(0)
+        _set_braking_motor_pwm_pct(0.0)
+        if GPIO is not None and braking_motor_gpio_initialised:
+            GPIO.output(braking_motor_power_pin, GPIO.LOW)
+        return
+
+    stalled_press = False
+    if error > 0.0 and error >= brake_press_stall_min_error_norm:
+        current_norm = float(encoder_norm)
+        if brake_press_max_norm is None:
+            brake_press_max_norm = current_norm
+            brake_press_last_progress_time = now
+        else:
+            if current_norm > (brake_press_max_norm + brake_press_stall_progress_norm):
+                brake_press_max_norm = current_norm
+                brake_press_last_progress_time = now
+            elif current_norm > brake_press_max_norm:
+                brake_press_max_norm = current_norm
+            elif current_norm < (brake_press_max_norm - brake_press_stall_noise_norm):
+                if (now - brake_press_last_progress_time) >= brake_press_stall_timeout_seconds:
+                    stalled_press = True
+    else:
+        brake_press_max_norm = None
+        brake_press_last_progress_time = now
+
+    if stalled_press:
         _set_braking_motor_direction(0)
         _set_braking_motor_pwm_pct(0.0)
         if GPIO is not None and braking_motor_gpio_initialised:
@@ -982,7 +1021,6 @@ def update_braking_motor_control(target_norm, encoder_norm, max_duty_pct=None):
             GPIO.output(braking_motor_power_pin, GPIO.HIGH)
         else:
             GPIO.output(braking_motor_power_pin, GPIO.LOW)
-
 
 def apply_braking_jog_drive(direction: int) -> None:
     if GPIO is not None and braking_motor_gpio_initialised:


### PR DESCRIPTION
### Motivation
- Prevent the braking motor from driving indefinitely when the brake encoder stops making meaningful progress and improve safety by stopping on a stalled press.
- Provide configurable thresholds to ignore encoder jitter and require sustained progress before allowing continued drive.

### Description
- Added new configuration parameters: `brake_press_stall_progress_norm`, `brake_press_stall_noise_norm`, `brake_press_stall_timeout_seconds`, and `brake_press_stall_min_error_norm` with sensible defaults for progress, noise tolerance, timeout, and minimum error to enable stall detection.
- Introduced global progress-tracking state variables `brake_press_max_norm` and `brake_press_last_progress_time` to record the high-watermark and last progress time of the braking encoder.
- Enhanced `update_braking_motor_control` to: reset tracking when inputs are `None` or calibration is active, update the high-watermark when encoder progresses, ignore small jitter, detect a stalled press after `brake_press_stall_timeout_seconds` of no meaningful progress while still far from the target, and stop PWM/direction when a stall or dead-zone/target condition is reached.
- Kept existing safety/GPIO handling intact and ensured the braking motor power pin is cleared when stopping due to stall, calibration, or idle conditions.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f91622488c83229492952c83869178)