### PR TITLE
Stabilize brake encoder calibration and release rezero

### DIFF
--- a/BRAKING_STEERING.py
+++ b/BRAKING_STEERING.py
@@ -628,7 +628,9 @@ brake_press_timestamps = deque()
 brake_release_rezero_drop_norm = 0.05
 brake_release_rezero_settle_seconds = 1.0
 brake_release_rezero_up_tolerance_norm = 0.005
-brake_autorange_margin_raw = 4
+brake_release_capture_max_norm = 0.20
+brake_release_target_max_norm = 0.10
+brake_release_min_shift_raw = 2
 brake_release_candidate_active = False
 brake_release_candidate_start_norm = None
 brake_release_candidate_lowest_norm = None
@@ -1065,6 +1067,7 @@ def get_braking_encoder_norm():
     global brake_release_candidate_lowest_raw
     global brake_release_candidate_last_drop_time
     global brake_release_candidate_disqualified
+    global braking_target_norm
     raw = read_braking_encoder_raw()
     now = time.monotonic()
     braking_latest_encoder_raw = raw
@@ -1078,22 +1081,6 @@ def get_braking_encoder_norm():
             return braking_last_valid_encoder_norm
         braking_latest_encoder_norm = None
         return None
-
-    # Expand (never shrink) brake calibration bounds when live readings exceed
-    # the recorded range. This prevents normalized output from getting pinned
-    # at 1.000/0.000 after a hard press/release that goes slightly outside the
-    # calibrated travel.
-    min_raw = braking_calibration_data.get("encoder_min_raw")
-    max_raw = braking_calibration_data.get("encoder_max_raw")
-    if min_raw is not None and max_raw is not None:
-        updated_min = int(min_raw)
-        updated_max = int(max_raw)
-        if raw < (updated_min - brake_autorange_margin_raw):
-            updated_min = int(raw)
-        if raw > (updated_max + brake_autorange_margin_raw):
-            updated_max = int(raw)
-        if updated_min != int(min_raw) or updated_max != int(max_raw):
-            save_braking_calibration(updated_min, updated_max)
 
     norm = braking_encoder_raw_to_norm(raw)
     braking_latest_encoder_norm = norm
@@ -1125,15 +1112,27 @@ def get_braking_encoder_norm():
 
     drop_amount = brake_release_candidate_start_norm - brake_release_candidate_lowest_norm
     settle_elapsed = now - brake_release_candidate_last_drop_time
+    in_release_zone = norm <= brake_release_capture_max_norm
+    targeting_release = braking_target_norm is not None and braking_target_norm <= brake_release_target_max_norm
+
     if (
         drop_amount >= brake_release_rezero_drop_norm
         and not brake_release_candidate_disqualified
         and settle_elapsed >= brake_release_rezero_settle_seconds
         and not braking_calibration_active
+        and in_release_zone
+        and targeting_release
     ):
         new_zero_raw = brake_release_candidate_lowest_raw
+        min_raw = braking_calibration_data.get("encoder_min_raw")
         max_raw = braking_calibration_data.get("encoder_max_raw")
-        if new_zero_raw is not None and max_raw is not None and int(max_raw) - int(new_zero_raw) > 0:
+        if (
+            new_zero_raw is not None
+            and min_raw is not None
+            and max_raw is not None
+            and int(new_zero_raw) < (int(min_raw) - brake_release_min_shift_raw)
+            and int(max_raw) - int(new_zero_raw) > 0
+        ):
             save_braking_calibration(int(new_zero_raw), int(max_raw))
 
         brake_release_candidate_active = True


### PR DESCRIPTION
### Motivation
- The brake encoder calibration was drifting during normal use because runtime auto-expansion of saved min/max bounds and an overly-permissive release rezero allowed small/noisy movements to repeatedly shift the saved homepoint.
- This made calibrated press and release positions wear off quickly and produced unusable braking behaviour.

### Description
- Removed the runtime auto-range expansion that continuously mutated saved brake `encoder_min_raw`/`encoder_max_raw` during live reads so the saved calibration no longer changes on small excursions. The deletion removes the previous autorange code path in `get_braking_encoder_norm()`.
- Added gated rezero behaviour with three new tuning constants: `brake_release_capture_max_norm`, `brake_release_target_max_norm`, and `brake_release_min_shift_raw` to ensure rezero only runs when the pedal is actually in the release zone, the controller is targeting release, and the new raw homepoint is meaningfully shifted compared to the stored min.
- Tightened the release-rezero decision in `get_braking_encoder_norm()` to require settled motion, `in_release_zone`, and `targeting_release`, and to only call `save_braking_calibration()` when the new zero is sufficiently lower than the saved min and the usable span remains positive.

### Testing
- Ran `python -m py_compile BRAKING_STEERING.py` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f938ef96548322a8dd242d2630d49d)