### PR TITLE
Read brake encoder high/low bytes with single I2C block read to prevent freeze/jitter

### DIFF
--- a/BRAKING_STEERING.py
+++ b/BRAKING_STEERING.py
@@ -534,10 +534,16 @@ def read_braking_encoder_raw():
     global braking_encoder_bus, braking_encoder_available
     if not braking_encoder_available or braking_encoder_bus is None:
         return None
-    for _ in range(max(1, int(braking_encoder_read_retries))):
+
+    retries = max(1, int(braking_encoder_read_retries))
+    for _ in range(retries):
         try:
-            high = braking_encoder_bus.read_byte_data(braking_encoder_i2c_address, 0x0C)
-            low = braking_encoder_bus.read_byte_data(braking_encoder_i2c_address, 0x0D)
+            # Read both bytes in one I2C transaction so high/low parts stay coherent
+            # while the brake is moving quickly under motor drive.
+            raw_bytes = braking_encoder_bus.read_i2c_block_data(braking_encoder_i2c_address, 0x0C, 2)
+            if len(raw_bytes) < 2:
+                raise OSError("Incomplete braking encoder read")
+            high, low = raw_bytes[0], raw_bytes[1]
             return ((high & 0x0F) << 8) | low
         except OSError:
             time.sleep(0.001)


### PR DESCRIPTION
### Motivation
- The brake encoder sometimes froze or produced jitter when the brake motor moved because sequential single-byte I2C reads can return mismatched high/low bytes while the sensor value changes under motion. 
- The change aims to provide coherent encoder samples during fast motion so position stays correct and stable.

### Description
- Replaced separate `read_byte_data` calls for the braking encoder with a single `read_i2c_block_data(..., 0x0C, 2)` call inside `read_braking_encoder_raw()` so the high and low bytes are read atomically. 
- Added a guard to detect incomplete block reads and treat them as retriable errors instead of accepting partial data. 
- Kept the existing retry loop and bus-reconnect/recovery behavior intact so the function still retries and reinitialises the SMBus on persistent failures.

### Testing
- Ran `python -m py_compile BRAKING_STEERING.py` and the module compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa01460ef08322b7d8c12405dc1bbf)